### PR TITLE
Fixes seeds

### DIFF
--- a/app/models/facility.rb
+++ b/app/models/facility.rb
@@ -1,3 +1,3 @@
 class Facility < ApplicationRecord
-    has_many :records, through: :records_facilities
+    has_and_belongs_to_many :records
 end

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -1,5 +1,5 @@
 class Record < ApplicationRecord
-  has_many :facilities, through: :records_facilities
+  has_and_belongs_to_many :facilities
   belongs_to :user
   belongs_to :room
 

--- a/db/migrate/20191210131154_rename_records_facilities_to_facilities_records.rb
+++ b/db/migrate/20191210131154_rename_records_facilities_to_facilities_records.rb
@@ -1,0 +1,5 @@
+class RenameRecordsFacilitiesToFacilitiesRecords < ActiveRecord::Migration[6.0]
+  def change
+    rename_table :records_facilities, :facilities_records
+  end
+end

--- a/db/migrate/20191210131442_rename_columns.rb
+++ b/db/migrate/20191210131442_rename_columns.rb
@@ -1,0 +1,6 @@
+class RenameColumns < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :facilities_records, :facilities_id, :facility_id
+    rename_column :facilities_records, :records_id, :record_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_10_054253) do
+ActiveRecord::Schema.define(version: 2019_12_10_131442) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,25 +18,25 @@ ActiveRecord::Schema.define(version: 2019_12_10_054253) do
   create_table "facilities", force: :cascade do |t|
     t.text "description"
     t.string "name"
-    t.bigint "rooms_id"
-    t.index ["rooms_id"], name: "index_facilities_on_rooms_id"
+    t.bigint "room_id"
+    t.index ["room_id"], name: "index_facilities_on_room_id"
+  end
+
+  create_table "facilities_records", force: :cascade do |t|
+    t.bigint "record_id"
+    t.bigint "facility_id"
+    t.index ["facility_id"], name: "index_facilities_records_on_facility_id"
+    t.index ["record_id"], name: "index_facilities_records_on_record_id"
   end
 
   create_table "records", force: :cascade do |t|
     t.date "date"
     t.time "time"
-    t.bigint "users_id"
-    t.bigint "rooms_id"
+    t.bigint "user_id"
+    t.bigint "room_id"
     t.integer "duration"
-    t.index ["rooms_id"], name: "index_records_on_rooms_id"
-    t.index ["users_id"], name: "index_records_on_users_id"
-  end
-
-  create_table "records_facilities", force: :cascade do |t|
-    t.bigint "records_id"
-    t.bigint "facilities_id"
-    t.index ["facilities_id"], name: "index_records_facilities_on_facilities_id"
-    t.index ["records_id"], name: "index_records_facilities_on_records_id"
+    t.index ["room_id"], name: "index_records_on_room_id"
+    t.index ["user_id"], name: "index_records_on_user_id"
   end
 
   create_table "rooms", force: :cascade do |t|
@@ -56,8 +56,8 @@ ActiveRecord::Schema.define(version: 2019_12_10_054253) do
     t.string "password"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.bigint "statuses_id"
-    t.index ["statuses_id"], name: "index_users_on_statuses_id"
+    t.bigint "status_id"
+    t.index ["status_id"], name: "index_users_on_status_id"
   end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -30,7 +30,7 @@ record2 = Record.create(date: DateTime.now.to_date,
                         duration: 60, room: room1, facilities: [facility1, facility2])
 record3 = Record.create(date: DateTime.now.to_date,
                         time: DateTime.now.to_time,
-                        duration: 30, room: room2, facility: [facility1])
+                        duration: 30, room: room2, facilities: [facility1])
 record4 = Record.create(date: DateTime.now.to_date,
                         time: DateTime.now.to_time,
-                        duration: 90, room: room2, facility: [facility2])
+                        duration: 90, room: room2, facilities: [facility2])


### PR DESCRIPTION
1. Changed associations to `has_and_belongs_to_many`
2. Renamed middle table. Parts must be in alphabetical order
3. Renamed reference columns
4. Fixed seeds.